### PR TITLE
Add text vertical bias support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ dependencies {
 | `pcv_textShadowRadius` | `string` | `0` | All | Sets text shadow/glow radius. |  
 | `pcv_textShadowDistX` | `float` | `0` | All | Sets text shadow/glow's x-axis distance. |  
 | `pcv_textShadowDistY` | `float` | `0` | All | Sets text shadow/glow's y-axis distance. |  
-| `pcv_backgroundOffset` | `dimension` | `0dp` | Pie, Fill | Sets a margin only for background. |  
-| `pcv_drawBackgroundBar` | `boolean` | `true` | Ring | Sets whether to draw background bar or not. |  
+| `pcv_textVerticalBias` | `float` | `0.5` | All | Sets text offset along y-axis. |
+| `pcv_backgroundOffset` | `dimension` | `0dp` | Pie, Fill | Sets a margin only for background. |
+| `pcv_drawBackgroundBar` | `boolean` | `true` | Ring | Sets whether to draw background bar or not. |
 | `pcv_backgroundBarThickness` | `dimension` | `16dp` | Ring | Sets background bar's thickness in DP. |  
 | `pcv_backgroundBarColor` | `color` | `#000000` | Ring | Sets background color. |  
 | `pcv_progressBarThickness` | `dimension` | `16dp` | Ring | Sets progress bar's thickness in DP. |  

--- a/percentagechartview/src/main/java/com/ramijemli/percentagechartview/PercentageChartView.java
+++ b/percentagechartview/src/main/java/com/ramijemli/percentagechartview/PercentageChartView.java
@@ -640,6 +640,17 @@ public class PercentageChartView extends View implements IPercentageChartView {
     }
 
     /**
+     * Sets the text vertical bias. Passing 0.25 means rendering the text in the 25% of the height of the progress.
+     * The default value is 0.5 which means rendering the text in the center of the progress vertically.
+     *
+     * @param textVerticalBias text vertical bias.
+     */
+    public void setTextVerticalBias(@FloatRange(from = 0, to = 1) float textVerticalBias) {
+        renderer.setTextVerticalBias(textVerticalBias);
+        postInvalidate();
+    }
+
+    /**
      * Gets the offset of the circular background.
      *
      * @return the offset of the circular background.-1 if chart mode is not set to pie.

--- a/percentagechartview/src/main/java/com/ramijemli/percentagechartview/renderer/BaseModeRenderer.java
+++ b/percentagechartview/src/main/java/com/ramijemli/percentagechartview/renderer/BaseModeRenderer.java
@@ -129,6 +129,7 @@ public abstract class BaseModeRenderer {
     private float mTextShadowRadius;
     private float mTextShadowDistY;
     private float mTextShadowDistX;
+    private float mTextVerticalBias;
     private Editable mTextEditor;
     private DynamicLayout mTextLayout;
 
@@ -314,6 +315,9 @@ public abstract class BaseModeRenderer {
             mTextShadowDistY = attrs.getFloat(R.styleable.PercentageChartView_pcv_textShadowDistY, 0);
         }
 
+        //TEXT VERTICAL BIAS
+        mTextVerticalBias = attrs.getFloat(R.styleable.PercentageChartView_pcv_textVerticalBias, 0.5f);
+
         //BACKGROUND OFFSET
         mBackgroundOffset = attrs.getDimensionPixelSize(
                 R.styleable.PercentageChartView_pcv_backgroundOffset,
@@ -439,7 +443,7 @@ public abstract class BaseModeRenderer {
 
     void drawText(Canvas canvas) {
         canvas.save();
-        canvas.translate(mCircleBounds.centerX(), mCircleBounds.centerY() - (mTextLayout.getHeight() >> 1));
+        canvas.translate(mCircleBounds.centerX(), mCircleBounds.top + (mCircleBounds.height() * mTextVerticalBias) - (mTextLayout.getHeight() >> 1));
         mTextLayout.draw(canvas);
         canvas.restore();
     }
@@ -838,6 +842,11 @@ public abstract class BaseModeRenderer {
         this.mTextShadowDistY = shadowDistY;
 
         mTextPaint.setShadowLayer(mTextShadowRadius, mTextShadowDistX, mTextShadowDistY, mTextShadowColor);
+        updateText();
+    }
+
+    public void setTextVerticalBias(float textVerticalBias) {
+        this.mTextVerticalBias = textVerticalBias;
         updateText();
     }
 

--- a/percentagechartview/src/main/res/values/attrs.xml
+++ b/percentagechartview/src/main/res/values/attrs.xml
@@ -58,6 +58,7 @@
         <attr name="pcv_textShadowDistY" format="float" />
         <attr name="pcv_textShadowDistX" format="float" />
         <attr name="pcv_textShadowColor" format="color" />
+        <attr name="pcv_textVerticalBias" format="float" />
 
         <!--PIE AND FILL MODES ATTRIBUTES-->
         <attr name="pcv_backgroundOffset" format="dimension" />


### PR DESCRIPTION
Add the ability to shift the text (percentage) which is currently in the center of the progress.

Now user can set `pcv_textVerticalBias` between 0 and 1 (0.5 is the default) to shift the text.
Also user can do that programmatically from code using `setTextVerticalBias(...)` method.